### PR TITLE
fix: fixes ipv4 serialization by adding missing bit-shift operations

### DIFF
--- a/pkg/protocols/ipv4/ipv4.go
+++ b/pkg/protocols/ipv4/ipv4.go
@@ -5,6 +5,15 @@ import (
 	"github.com/swagnikdutta/netprobe/pkg/protocols"
 )
 
+func calculateTotalLength(p *Packet) (*uint16, error) {
+	b, err := p.Serialize()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error serializing ip packet")
+	}
+	length := uint16(len(b))
+	return &length, nil
+}
+
 func CreatePacket(h Header, payload []byte) (*Packet, []byte, error) {
 	p := &Packet{
 		Header: &Header{
@@ -18,18 +27,21 @@ func CreatePacket(h Header, payload []byte) (*Packet, []byte, error) {
 		Payload: payload,
 	}
 
-	// TODO: This needs to be calculated I think. Try once. Otherwise put it in header
-	p.Header.TotalLength = 50
+	length, err := calculateTotalLength(p)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "error calculating total length of packet")
+	}
+	p.Header.TotalLength = *length
 
 	headerSerialized, err := p.Header.Serialize()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error serializing IPv4 packet header")
+		return nil, nil, errors.Wrapf(err, "error serializing ip packet header")
 	}
 	p.Header.Checksum = protocols.CalculateChecksum(headerSerialized)
 
 	packetSerialized, err := p.Serialize()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error serializing IPv4 packet")
+		return nil, nil, errors.Wrapf(err, "error serializing ip packet")
 	}
 
 	return p, packetSerialized, nil

--- a/pkg/protocols/ipv4/serializer.go
+++ b/pkg/protocols/ipv4/serializer.go
@@ -9,7 +9,10 @@ import (
 
 func (h *Header) Serialize() ([]byte, error) {
 	buf := new(bytes.Buffer)
-	if err := protocols.WriteBinary(buf, h.Version, h.IHL, h.TypeOfService, h.TotalLength, h.Identification, h.Flags, h.FragmentOffset, h.TTL, h.Protocol, h.Checksum, h.SourceIP, h.DestinationIP); err != nil {
+	versionIHL := h.Version<<4 | h.IHL
+	flagsAndOffset := uint16(h.Flags)<<13 | h.FragmentOffset
+
+	if err := protocols.WriteBinary(buf, versionIHL, h.TypeOfService, h.TotalLength, h.Identification, flagsAndOffset, h.TTL, h.Protocol, h.Checksum, h.SourceIP, h.DestinationIP); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil

--- a/pkg/protocols/ipv4/types.go
+++ b/pkg/protocols/ipv4/types.go
@@ -5,9 +5,10 @@ import "net"
 // Header represents the header of an IPv4 Packet.
 // This struct defines the fields that make up the IPv4 packet header,
 type Header struct {
-	Version        uint8
-	IHL            uint8
-	TypeOfService  uint8
+	Version       uint8
+	IHL           uint8
+	TypeOfService uint8
+	// Total Length is the length of the datagram, measured in octets, including internet header and data
 	TotalLength    uint16
 	Identification uint16
 	Flags          uint8


### PR DESCRIPTION
This PR
- Fixes the header serialization. Combines `Version` and `IHL` into a single 8-bit unsigned integer as it should be.
- Removes hardcoding of `TotalLength` of IP header